### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,9 +3,9 @@ class ItemsController < ApplicationController
   #before_action :set_item, only: [:edit, :update, :show, :destroy]
 
 
-  #def index
-    #@items = Item.all#.order("created_at DESC")
-  #end
+  def index
+    @items = Item.all.order("created_at DESC")
+  end
 
   def new
     @item = Item.new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,6 +25,7 @@ class Item < ApplicationRecord
   validates :image,presence: true
 
 
+
   belongs_to :user
   #has_one :order
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,8 +133,7 @@
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%#= image_tag "item-sample.png", class: "item-img" %>
-          <%= image_tag "#{item.png}, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img"  %>
 
           
           <%# if  items.order %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,8 @@
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%#= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag "#{item.png}, class: "item-img" %>
 
           
           <%# if  items.order %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,20 +128,21 @@
     <ul class='item-lists'>
 
       
-      <%# if  @items.present? %>
-      <%# @items.each do |item| %>
+      <% if  @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to root_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
           
-          <%# if  @item.order %>
-          <%#div class='sold-out'>
+          <%# if  item.order %>
+          <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>
           
+
 
         </div>
         <div class='item-info'>
@@ -149,7 +150,7 @@
             <%#= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%#= item.price %>円<br><%#= item.delivery_fee.name %></span>
+            <span><%#= item.price %>円<br><%#= item.delivery_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -158,10 +159,10 @@
         </div>
       <% end %>
       </li>
-      <%# end %>
-      <%# else %>
+      <% end %>
+      <% else %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to "#" do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -177,7 +178,7 @@
         </div>
         <% end %>
       </li>
-      <%# end %>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,13 +131,13 @@
       <% if  @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to root_path(item.id) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
           
-          <%# if  item.order %>
-          <div class='sold-out'>
+          <%# if  items.order %>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# end %>
@@ -147,10 +147,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%#= item.name %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%#= item.price %>円<br><%#= item.delivery_charge.name %></span>
+            <span><%= item.product_price %>円<br><%= item.delivery_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :index]
 end


### PR DESCRIPTION
# what
商品一覧表示ページは、ログイン状況に関係なく、誰でも見ることができること。
- [ ] 出品されている商品が一覧で表示されること。
- [ ] 画像が表示されており、画像がリンク切れなどにならないこと（デプロイのタスクにあるとおり、実装中にHerokuの仕様による商品画像が適切に表示されなくなる問題は発生するが、最後にS3を導入することで、この問題は解消される）。
- [ ] 商品が出品されていない状態では、ダミーの商品情報が表示されること。
- [ ] 左上から、出品された日時が新しい順に表示されること。
- [ ] 商品出品時に登録した情報のうち、「画像・商品名・価格・配送料の負担」の4つの情報が、見本アプリと同様の形で表示されること。
https://gyazo.com/654620bf1183dbaf9c7e667d0e0ac3a0

# why
よろしくお願いします。